### PR TITLE
Use single source of truth

### DIFF
--- a/backend/src/services/annotation.py
+++ b/backend/src/services/annotation.py
@@ -52,7 +52,10 @@ class AnnotationCRUD(SparkRequestHandler):
         PREFIX dct: <http://purl.org/dc/terms/>
         PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
 
-        SELECT * WHERE
+        SELECT * 
+        FROM <http://mu.semte.ch/application/probe/user-annotations>
+        FROM <http://mu.semte.ch/application/probe/model-annotations>
+        WHERE
         {{
             VALUES ?besluit {{<{}> }}
             ?besluit ext:hasAnnotation ?anno .


### PR DESCRIPTION
besluiten zitten momenteel in meerdere graphs, om te voorkomen dat de BEAT één besluit/annotatie meerdere keren toont voegen we de graph toe aan de select query.

Only use these graphs

http://mu.semte.ch/application/probe/user-annotations http://mu.semte.ch/application/probe/model-annotations